### PR TITLE
Performance patch for MainSpoonerUpdates thread call

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -15,6 +15,8 @@ local KeepSelfInDb = true
 local FocusTarget
 local FocusTargetPos
 local FreeFocus = false
+local MessageRate = 70
+local MessageInterval = true
 local showEntityHandles = false
 
 local SpoonerPrompts, ClearTasksPrompt, DetachPrompt
@@ -2767,32 +2769,38 @@ function MainSpoonerUpdates()
 		elseif FocusTarget and not FreeFocus then
 			entity = FocusTarget
 		end
-
-		SendNUIMessage({
-			type = 'updateSpoonerHud',
-			entity = entity,
-			netId = NetworkGetEntityIsNetworked(entity) and ObjToNet(entity),
-			entityType = GetSpoonerEntityType(entity),
-			modelName = GetModelName(GetSpoonerEntityModel(entity)),
-			attachedEntity = AttachedEntity,
-			speed = string.format('%.2f', Speed),
-			currentSpawn = CurrentSpawn and CurrentSpawn.modelName,
-			rotateMode = RotateMode,
-			adjustMode = AdjustMode,
-			speedMode = SpeedMode,
-			placeOnGround = PlaceOnGround,
-			adjustSpeed = AdjustSpeed,
-			rotateSpeed = RotateSpeed,
-			cursorX = string.format('%.2f', spawnPos.x),
-			cursorY = string.format('%.2f', spawnPos.y),
-			cursorZ = string.format('%.2f', spawnPos.z),
-			camX = string.format('%.2f', x2),
-			camY = string.format('%.2f', y2),
-			camZ = string.format('%.2f', z2),
-			camHeading = string.format('%.2f', yaw2),
-			focusTarget = FocusTarget,
-			freeFocus = FreeFocus
-		})
+        if MessageInterval then
+            MessageInterval = false
+            Citizen.CreateThread(function()
+                Citizen.Wait(MessageRate)
+                MessageInterval = true
+            end)
+			SendNUIMessage({
+				type = 'updateSpoonerHud',
+				entity = entity,
+				netId = NetworkGetEntityIsNetworked(entity) and ObjToNet(entity),
+				entityType = GetSpoonerEntityType(entity),
+				modelName = GetModelName(GetSpoonerEntityModel(entity)),
+				attachedEntity = AttachedEntity,
+				speed = string.format('%.2f', Speed),
+				currentSpawn = CurrentSpawn and CurrentSpawn.modelName,
+				rotateMode = RotateMode,
+				adjustMode = AdjustMode,
+				speedMode = SpeedMode,
+				placeOnGround = PlaceOnGround,
+				adjustSpeed = AdjustSpeed,
+				rotateSpeed = RotateSpeed,
+				cursorX = string.format('%.2f', spawnPos.x),
+				cursorY = string.format('%.2f', spawnPos.y),
+				cursorZ = string.format('%.2f', spawnPos.z),
+				camX = string.format('%.2f', x2),
+				camY = string.format('%.2f', y2),
+				camZ = string.format('%.2f', z2),
+				camHeading = string.format('%.2f', yaw2),
+				focusTarget = FocusTarget,
+				freeFocus = FreeFocus
+			})
+		end
 
 		if CheckControls(IsDisabledControlPressed, 0, Config.IncreaseSpeedControl) then
 			if SpeedMode == 0 then

--- a/client.lua
+++ b/client.lua
@@ -2771,8 +2771,8 @@ function MainSpoonerUpdates()
 		end
         if MessageInterval then
             MessageInterval = false
-            Citizen.CreateThread(function()
-                Citizen.Wait(MessageRate)
+            CreateThread(function()
+                Wait(MessageRate)
                 MessageInterval = true
             end)
 			SendNUIMessage({

--- a/client.lua
+++ b/client.lua
@@ -324,29 +324,21 @@ function GetInView(x1, y1, z1, pitch, roll, yaw)
 end
 
 function GetModelName(model)
-	for _, name in ipairs(Peds) do
-		if model == GetHashKey(name) then
-			return name
-		end
-	end
+	if PedsHashLookup[model] then
+        return PedsHashLookup[model]
+    end
 
-	for _, name in ipairs(Vehicles) do
-		if model == GetHashKey(name) then
-			return name
-		end
-	end
+    if VehiclesHashLookup[model] then
+        return VehiclesHashLookup[model]
+    end
 
-	for _, name in ipairs(Objects) do
-		if model == GetHashKey(name) then
-			return name
-		end
-	end
+    if ObjectsHashLookup[model] then
+        return ObjectsHashLookup[model]
+    end
 
-	for _, name in ipairs(Pickups) do
-		if model == GetHashKey(name) then
-			return name
-		end
-	end
+    if PickupsHashLookup[model] then
+        return PickupsHashLookup[model]
+    end
 
 	return tostring(model)
 end

--- a/data/gta5/objects.lua
+++ b/data/gta5/objects.lua
@@ -18503,3 +18503,6 @@ Objects = {
 	"xs3_prop_int_xmas_tree_01",
 	"zprop_bin_01a_old",
 }
+
+ObjectsHashLookup = {}
+for _, name in ipairs(Objects) do ObjectsHashLookup[GetHashKey(name)] = name; end

--- a/data/gta5/peds.lua
+++ b/data/gta5/peds.lua
@@ -934,3 +934,6 @@ Peds = {
 	"U_M_Y_Ushi",
 	"U_M_Y_Zombie_01",
 }
+
+PedsHashLookup = {}
+for _, name in ipairs(Peds) do PedsHashLookup[GetHashKey(name)] = name; end

--- a/data/gta5/pickups.lua
+++ b/data/gta5/pickups.lua
@@ -1,2 +1,5 @@
 Pickups = {
 }
+
+PickupsHashLookup = {}
+for _, name in ipairs(Pickups) do PickupsHashLookup[GetHashKey(name)] = name; end

--- a/data/gta5/vehicles.lua
+++ b/data/gta5/vehicles.lua
@@ -758,3 +758,6 @@ Vehicles = {
 	"zr3803",
 	"Ztype",
 }
+
+VehiclesHashLookup = {}
+for _, name in ipairs(Vehicles) do VehiclesHashLookup[GetHashKey(name)] = name; end

--- a/data/rdr3/objects.lua
+++ b/data/rdr3/objects.lua
@@ -16948,3 +16948,6 @@ Objects = {
 	"yarrow03_p",
 	"yarrow04_p",
 }
+
+ObjectsHashLookup = {}
+for _, name in ipairs(Objects) do ObjectsHashLookup[GetHashKey(name)] = name; end

--- a/data/rdr3/peds.lua
+++ b/data/rdr3/peds.lua
@@ -1982,3 +1982,6 @@ Peds = {
 	"western_saddle_03",
 	"western_saddle_04",
 }
+
+PedsHashLookup = {}
+for _, name in ipairs(Peds) do PedsHashLookup[GetHashKey(name)] = name; end

--- a/data/rdr3/pickups.lua
+++ b/data/rdr3/pickups.lua
@@ -147,3 +147,6 @@ Pickups = {
 	"PICKUP_WEAPON_THROWN_TOMAHAWK_IMPROVED",
 	"PICKUP_WEAPON_THROWN_TOMAHAWK_MP",
 }
+
+PickupsHashLookup = {}
+for _, name in ipairs(Pickups) do PickupsHashLookup[GetHashKey(name)] = name; end

--- a/data/rdr3/vehicles.lua
+++ b/data/rdr3/vehicles.lua
@@ -115,3 +115,6 @@ Vehicles = {
 	"wintercoalcar",
 	"winterSteamer",
 }
+
+VehiclesHashLookup = {}
+for _, name in ipairs(Vehicles) do VehiclesHashLookup[GetHashKey(name)] = name; end


### PR DESCRIPTION
- Modify GetModelName so that it uses hash lookup tables instead of iterating through Objects/Vehicles/Peds/Pickups and hashing each name until there is a match every frame.
  - When aiming at no entity, main loop thread improved from ~1033ms to ~11ms

Before:
<img width="866" alt="spooner_before" src="https://github.com/kibook/spooner/assets/103921646/43473235-3cff-41e7-a99e-d454f14ecbc7">
After:
<img width="865" alt="spooner_after" src="https://github.com/kibook/spooner/assets/103921646/f6f16ecf-d46f-4e7f-bff7-9f9e175505ae">

- Add a rate limit for the 'updateSpoonerHud' SendNUIMessage. Without a rate limit, the increased frame rate overloads the NUI and it struggles to keep up with the messages.